### PR TITLE
Add test

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -193,7 +193,7 @@ parse_database_error <- function(msg) {
 
   # Remove the square-bracketed context from the database error
   cnd_body <- Reduce(
-    function(p, x) function(p, x) gsub(p, "", x, fixed = TRUE),
+    function(p, x) gsub(p, "", x, fixed = TRUE),
     cnd_context_driver,
     cnd_msg[-1],
     right = TRUE


### PR DESCRIPTION
I think you accidentally added an extra `function(p, x)` on line 196 of `R/utils.R`, so I removed that.

I added a test that fails for `odbc` version 1.6.1 but passes for this branch. The query in the test's error message with 35,000 items in the `IN` clause wouldn't actually raise the "maximum number of expressions in a list exceeded" SQL error, but I didn't want to add a test that would take 45 minutes to fail. I experimented with longer and longer error messages and timed them in an Ubuntu 22.04 container with 1 core and 2 Gb RAM (not a very powerful container). `rethrow_database_error(err_msg_w_really_long_query, call = NULL)` takes 7 - 20 seconds in this environment. I think this straddles the line well between being slow enough that `expect_lt(elapsed_time, 5)` isn't flaky, but fast enough that the test suite doesn't take forever if the test fails.